### PR TITLE
feat: refresh portfolio styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-inter);
   /* Before: --font-mono: var(--font-geist-mono); */
   --font-mono: var(--font-jetbrains); /* Now every className="font-mono" will use JetBrains Mono */
 }
@@ -28,7 +28,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), sans-serif;
 }
 
 html { scroll-behavior: smooth; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,11 +3,17 @@ import "./globals.css";
 import Providers from "./providers";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import { JetBrains_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
 
 const jetbrainsMono = JetBrains_Mono({
-  subsets: ["latin"],            // Suitable for English/ASCII text
-  variable: "--font-jetbrains",  // The CSS var name that will be connected to Tailwind
+  subsets: ["latin"],
+  variable: "--font-jetbrains",
   display: "swap",
 });
 
@@ -18,8 +24,15 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="he" dir="ltr" suppressHydrationWarning className={jetbrainsMono.variable}>
-      <body className="bg-neutral-950 text-neutral-50 antialiased transition-colors duration-300">
+    <html
+      lang="he"
+      dir="ltr"
+      suppressHydrationWarning
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+    >
+      <body
+        className="bg-gradient-to-br from-neutral-100 via-white to-neutral-200 text-neutral-900 dark:from-neutral-900 dark:via-neutral-950 dark:to-black dark:text-neutral-50 antialiased transition-colors duration-300"
+      >
         <Providers>
           <Navbar />
           {children}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,8 +1,8 @@
 export default function Footer() {
   return (
-    <footer className="border-t border-neutral-800">
-      <div className="mx-auto max-w-6xl px-4 py-8 text-sm text-neutral-400">
-        © {new Date().getFullYear()} Daniel Pilant
+    <footer className="border-t border-neutral-800 mt-16">
+      <div className="mx-auto max-w-6xl px-4 py-8 text-center text-sm text-neutral-500">
+        © {new Date().getFullYear()} Daniel Pilant · Built with Next.js & Tailwind CSS
       </div>
     </footer>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,26 +1,39 @@
 import Link from "next/link";
-
+import ThemeToggle from "./ThemeToggle";
 
 function Navbar() {
   return (
-    <header className="sticky top-0 z-50 backdrop-blur border-b border-neutral-800 bg-neutral-950/60">
-      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="font-semibold tracking-tight">
+    <header className="sticky top-0 z-50 border-b border-neutral-800 bg-neutral-900/70 backdrop-blur-md supports-[backdrop-filter]:bg-neutral-900/60">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <Link
+          href="/"
+          className="font-semibold tracking-tight transition-colors hover:text-sky-400"
+        >
           Daniel Pilant • Software Engineer
         </Link>
         <nav className="hidden md:flex items-center gap-6 text-sm">
-          <Link href="/projects" className="opacity-80 hover:opacity-100">
+          <Link
+            href="/projects"
+            className="opacity-80 transition-colors hover:opacity-100 hover:text-sky-400"
+          >
             Projects
           </Link>
-          <Link href="/resume" className="opacity-80 hover:opacity-100">
+          <Link
+            href="/resume"
+            className="opacity-80 transition-colors hover:opacity-100 hover:text-sky-400"
+          >
             Resume
           </Link>
-          <Link href="/contact" className="opacity-80 hover:opacity-100">
+          <Link
+            href="/contact"
+            className="opacity-80 transition-colors hover:opacity-100 hover:text-sky-400"
+          >
             Contact
           </Link>
-        
         </nav>
-        {/* On mobile, you can put ThemeToggle next to the hamburger menu */}
+        <div className="ml-4">
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -6,11 +6,11 @@ export default function ProjectCard({ p }: { p: Project }) {
   return (
     <Link
       href={`/projects/${p.slug}`}
-      className="group block overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 hover:border-primary-500 shadow-lg hover:shadow-xl transition-all duration-300 relative"
+      className="group relative block overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 shadow-lg transition-all duration-300 hover:border-sky-500 hover:shadow-xl"
     >
       {/* Featured badge */}
       {p.featured && (
-        <span className="absolute top-3 right-3 z-10 bg-primary-500/90 text-xs text-white px-3 py-1 rounded-full shadow font-semibold tracking-wide">
+        <span className="absolute top-3 right-3 z-10 rounded-full bg-sky-500/90 px-3 py-1 text-xs font-semibold tracking-wide text-white shadow">
           Featured
         </span>
       )}
@@ -36,7 +36,9 @@ export default function ProjectCard({ p }: { p: Project }) {
 
       {/* Text */}
       <div className="p-6">
-        <div className="text-xl font-bold mb-1 group-hover:text-primary-400 transition-colors duration-200">{p.title}</div>
+        <div className="mb-1 text-xl font-bold transition-colors duration-200 group-hover:text-sky-400">
+          {p.title}
+        </div>
         <div className="text-neutral-400 text-base mt-1 line-clamp-2 min-h-[2.5em]">{p.tagline}</div>
 
         <div className="flex flex-wrap gap-2 mt-4">


### PR DESCRIPTION
## Summary
- add Inter font and gradient background for a lighter, modern feel
- integrate theme toggle and refine navigation styles
- unify accent colors and polish cards and footer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd3472cf98832a99599650e53fb97b