### PR TITLE
feat: refresh portfolio design

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,4 +1,6 @@
 "use client";
+// CHANGELOG:
+// - Updated contact form styling to match new palette.
 import { useState } from "react";
 
 export default function ContactPage() {
@@ -11,18 +13,18 @@ export default function ContactPage() {
 
   return (
     <main className="mx-auto max-w-xl px-4 py-16 flex flex-col items-center min-h-[70vh]">
-      <div className="w-full bg-neutral-900/80 rounded-2xl shadow-lg border border-neutral-800 p-8 flex flex-col items-center">
+      <div className="w-full border border-white/10 bg-white/[0.02] p-8 flex flex-col items-center shadow-[0_0_0_1px_rgba(255,255,255,0.02)_inset]">
         <h1 className="text-4xl font-extrabold mb-6 tracking-tight text-primary-400 drop-shadow-lg text-center">Contact Me :)</h1>
         {sent ? (
-          <div className="p-4 border border-green-600/40 rounded-lg bg-green-900/20 text-green-200 w-full text-center">
+          <div className="p-4 border border-success-500/40 bg-success-500/20 text-success-500 w-full text-center">
             Form submitted (Demo). Can be connected to Formspree/Email later.
           </div>
         ) : (
           <form onSubmit={onSubmit} className="space-y-4 w-full">
-            <input className="w-full rounded-lg bg-neutral-800 border border-neutral-700 px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-primary-500 transition" placeholder="Name" required />
-            <input type="email" className="w-full rounded-lg bg-neutral-800 border border-neutral-700 px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-primary-500 transition" placeholder="Email" required />
-            <textarea className="w-full rounded-lg bg-neutral-800 border border-neutral-700 px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-primary-500 transition" rows={5} placeholder="Message" required />
-            <button className="rounded-lg px-6 py-2 bg-primary-500 text-white font-semibold shadow hover:bg-primary-400 transition w-full mt-2">Send</button>
+            <input className="w-full bg-white/[0.05] border border-white/10 px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-primary-400 transition" placeholder="Name" required />
+            <input type="email" className="w-full bg-white/[0.05] border border-white/10 px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-primary-400 transition" placeholder="Email" required />
+            <textarea className="w-full bg-white/[0.05] border border-white/10 px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-primary-400 transition" rows={5} placeholder="Message" required />
+            <button className="inline-flex items-center justify-center px-6 py-2 text-sm font-medium border border-white/10 bg-primary-500/10 hover:bg-primary-500/20 hover:shadow-lg active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition w-full mt-2">Send</button>
           </form>
         )}
       </div>

--- a/app/experiences/[slug]/page.tsx
+++ b/app/experiences/[slug]/page.tsx
@@ -1,4 +1,6 @@
 // app/experience/[slug]/page.tsx
+// CHANGELOG:
+// - Updated experience detail styling to new palette and sharp corners.
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -14,26 +16,26 @@ export default function ExperiencePage({ params }: { params: { slug: string } })
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-10">
-      <Link href="/experiences" className="text-sm text-neutral-400 hover:text-neutral-200">
+      <Link href="/experiences" className="text-sm underline text-primary-400 hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400">
         ← Back to Experience
       </Link>
 
       <h1 className="mt-4 text-3xl md:text-5xl font-bold">{exp.title}</h1>
-      <p className="mt-2 text-neutral-400">{exp.meta}</p>
+      <p className="mt-2 text-muted-500">{exp.meta}</p>
 
       <div className="mt-6 relative w-full aspect-[16/9]">
         <Image
           src={exp.cover}
           alt={exp.title}
           fill
-          className="object-cover rounded-2xl border border-neutral-800"
+          className="object-cover border border-white/10"
           sizes="100vw"
         />
       </div>
 
-      <p className="mt-6 text-neutral-300 leading-relaxed">{exp.long}</p>
+      <p className="mt-6 text-muted-500 leading-relaxed">{exp.long}</p>
 
-      <ul className="mt-6 list-disc list-inside text-neutral-300 space-y-1">
+      <ul className="mt-6 list-disc list-inside text-muted-500 space-y-1">
         {exp.highlights.map((h) => <li key={h}>{h}</li>)}
       </ul>
 
@@ -44,7 +46,7 @@ export default function ExperiencePage({ params }: { params: { slug: string } })
               src={src}
               alt={`${exp.title} photo ${i + 1}`}
               fill
-              className="object-cover rounded-xl border border-neutral-800"
+              className="object-cover border border-white/10"
               sizes="(min-width: 1024px) 33vw, 50vw"
             />
           </div>

--- a/app/experiences/page.tsx
+++ b/app/experiences/page.tsx
@@ -1,4 +1,6 @@
 // app/experience/page.tsx
+// CHANGELOG:
+// - Updated colors, focus rings and sharp corners.
 import Image from "next/image";
 import Link from "next/link";
 import { experiences } from "@/data/experience";
@@ -7,7 +9,7 @@ export default function ExperienceIndex() {
   return (
     <main className="mx-auto max-w-5xl px-4 py-10">
       <h1 className="text-3xl md:text-5xl font-bold text-center">Experience</h1>
-      <p className="mt-3 text-center text-neutral-400">
+      <p className="mt-3 text-center text-muted-500">
         Leadership, teaching, and community building.
       </p>
 
@@ -16,7 +18,7 @@ export default function ExperienceIndex() {
           <Link
             key={exp.slug}
             href={`/experiences/${exp.slug}`}
-            className="group block rounded-2xl overflow-hidden border border-neutral-800 bg-neutral-950 hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+            className="group block overflow-hidden border border-white/10 bg-white/[0.02] hover:bg-white/[0.04] hover:-translate-y-0.5 transition shadow-[0_0_0_1px_rgba(255,255,255,0.02)_inset] focus:outline-none focus-visible:ring-2 focus-visible:ring-info-500"
           >
             <div className="relative h-44 w-full">
               <Image
@@ -30,16 +32,16 @@ export default function ExperienceIndex() {
             </div>
             <div className="p-6">
               <h3 className="font-semibold">{exp.title}</h3>
-              <p className="text-sm text-neutral-400">{exp.meta}</p>
-              <ul className="mt-3 space-y-1 text-neutral-300 text-sm leading-relaxed">
+              <p className="text-sm text-muted-500">{exp.meta}</p>
+              <ul className="mt-3 space-y-1 text-muted-500 text-sm leading-relaxed">
                 {exp.bullets.map((b) => (
                   <li key={b} className="flex gap-2">
-                    <span className="mt-[6px] h-[6px] w-[6px] rounded-full bg-neutral-600 shrink-0 group-hover:bg-sky-500 transition-colors" />
+                    <span className="mt-[6px] h-[6px] w-[6px] rounded-full bg-neutral-600 shrink-0 group-hover:bg-primary-400 transition-colors" />
                     <span>{b}</span>
                   </li>
                 ))}
               </ul>
-              <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-sky-400 group-hover:text-sky-300">
+              <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary-400 group-hover:text-primary-500">
                 View details →
               </div>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,35 +1,47 @@
 @import "tailwindcss";
 
+/* CHANGELOG:
+ * - Introduced animated gradient background with reduced-motion fallback.
+ * - Added elevate utility and sharp global styling.
+ */
+
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --bg1: #0b1220;
+  --bg2: #101a2f;
+  --bg3: #0b1220;
+  --noise: radial-gradient(transparent 65%, rgba(255,255,255,.04) 66%) 0 0/3px 3px;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
   --font-sans: var(--font-inter);
-  /* Before: --font-mono: var(--font-geist-mono); */
-  --font-mono: var(--font-jetbrains); /* Now every className="font-mono" will use JetBrains Mono */
-}
-
-@keyframes blink {
-  0%, 49% { opacity: 1; }
-  50%, 100% { opacity: 0; }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0b0113;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-sans), sans-serif;
+  --font-mono: var(--font-jetbrains);
 }
 
 html { scroll-behavior: smooth; }
+
+body {
+  background:
+    radial-gradient(1200px 600px at 10% 0%, rgba(34,211,238,.10), transparent 40%),
+    radial-gradient(900px 500px at 90% 20%, rgba(244,114,182,.08), transparent 45%),
+    linear-gradient(120deg, var(--bg1), var(--bg2) 50%, var(--bg3));
+  background-size: 200% 200%;
+  animation: bg-pan 18s ease-in-out infinite;
+  color: #e6ebf5;
+  font-family: var(--font-sans), sans-serif;
+}
+
+@keyframes bg-pan {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body { animation: none; }
+}
+
+.elevate {
+  backdrop-filter: blur(8px);
+  background: color-mix(in oklab, #0b1220 70%, white 0%);
+}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,8 @@
 // app/layout.tsx
+/**
+ * CHANGELOG:
+ * - Simplified body styles to defer to global animated background.
+ */
 import "./globals.css";
 import Providers from "./providers";
 import Navbar from "@/components/Navbar";
@@ -30,9 +34,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       suppressHydrationWarning
       className={`${inter.variable} ${jetbrainsMono.variable}`}
     >
-      <body
-        className="bg-gradient-to-br from-neutral-100 via-white to-neutral-200 text-neutral-900 dark:from-neutral-900 dark:via-neutral-950 dark:to-black dark:text-neutral-50 antialiased transition-colors duration-300"
-      >
+      <body className="antialiased transition-colors">
         <Providers>
           <Navbar />
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,7 @@
 // app/page.tsx
+// CHANGELOG:
+// - Refreshed hero with gradient text and polished CTAs.
+// - Updated colors and focus states across sections.
 import Typewriter from "@/components/Typewriter";
 import Image from "next/image";
 import Link from "next/link";
@@ -26,7 +29,7 @@ const lines = [
         id="home"
         className="min-h-[80vh] flex flex-col items-center justify-center text-center"
       >
-        <h1 className="text-4xl md:text-6xl font-extrabold">
+        <h1 className="text-4xl md:text-6xl font-extrabold tracking-tight bg-gradient-to-r from-primary-400 via-info-500 to-accent-500 bg-clip-text text-transparent">
           Daniel Pilant
         </h1>
 
@@ -35,32 +38,38 @@ const lines = [
           <Typewriter lines={lines} />
         </div>
 
-        <p className="mt-6 text-lg text-neutral-300 max-w-2xl">
+        <p className="mt-6 text-lg text-muted-500 max-w-2xl">
           Software Engineer • Product Builder • Community Manager • Teacher & Tutor
         </p>
 
         <div className="mt-8 flex gap-4">
-          <Link href="/projects" className="px-6 py-3 rounded-lg bg-sky-600 hover:bg-sky-500 transition">
+          <Link
+            href="/projects"
+            className="inline-flex items-center justify-center px-6 py-3 text-sm font-medium border border-white/10 bg-primary-500/10 hover:bg-primary-500/20 hover:shadow-lg active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition"
+          >
             View Projects
           </Link>
-          <Link href="/contact" className="px-6 py-3 rounded-lg border border-neutral-700 hover:bg-neutral-900 transition">
+          <Link
+            href="/contact"
+            className="inline-flex items-center justify-center px-6 py-3 text-sm font-medium border border-white/10 bg-transparent hover:bg-white/5 hover:shadow-lg active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition"
+          >
             Contact
           </Link>
         </div>
       </section>
       
       {/* ABOUT */}
-      <section id="about" className="py-24 border-t border-neutral-800 text-center">
+      <section id="about" className="py-24 border-t border-white/10 text-center">
         <h2 className="text-3xl font-bold mb-6">About Me</h2>
-        <p className="text-neutral-300 max-w-2xl mx-auto whitespace-pre-line leading-relaxed">
+        <p className="text-muted-500 max-w-2xl mx-auto whitespace-pre-line leading-relaxed">
           {aboutMe}
         </p>
       </section>
 
       {/* FEATURED PROJECTS */}
-      <section id="projects" className="py-24 border-t border-neutral-800 text-center">
+      <section id="projects" className="py-24 border-t border-white/10 text-center">
         <h2 className="text-3xl font-bold mb-6">Featured Projects</h2>
-        <p className="text-neutral-400 mb-8">Code, demos and measurable impact.</p>
+        <p className="text-muted-500 mb-8">Code, demos and measurable impact.</p>
 
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
           {featured.map((p) => (
@@ -71,7 +80,7 @@ const lines = [
         <div className="mt-8">
           <Link
             href="/projects"
-            className="text-sm text-sky-400 underline hover:text-sky-300"
+            className="text-sm text-primary-400 underline hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
           >
             See all →
           </Link>
@@ -79,9 +88,9 @@ const lines = [
       </section>
 
       {/* EXPERIENCE (preview) */}
-      <section id="experiences" className="py-24 border-t border-neutral-800">
+      <section id="experiences" className="py-24 border-t border-white/10">
         <h2 className="text-3xl font-bold mb-6 text-center">Community Partnership and Volunteering</h2>
-        <p className="text-neutral-400 text-center max-w-2xl mx-auto">
+        <p className="text-muted-500 text-center max-w-2xl mx-auto">
           Leadership, teaching, and community building.
         </p>
 
@@ -91,7 +100,7 @@ const lines = [
               key={exp.slug}
               href={`/experiences/${exp.slug}`}
               aria-label={`Open ${exp.title}`}
-              className="group block rounded-2xl overflow-hidden border border-neutral-800 bg-neutral-950 hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+              className="group block overflow-hidden border border-white/10 bg-white/[0.02] hover:bg-white/[0.04] hover:-translate-y-0.5 transition shadow-[0_0_0_1px_rgba(255,255,255,0.02)_inset] focus:outline-none focus-visible:ring-2 focus-visible:ring-info-500"
             >
               {/* Image */}
               <div className="relative h-44 w-full">
@@ -108,18 +117,18 @@ const lines = [
               {/* Card body */}
               <div className="p-6">
                 <h3 className="font-semibold">{exp.title}</h3>
-                <p className="text-sm text-neutral-400">{exp.meta}</p>
+                <p className="text-sm text-muted-500">{exp.meta}</p>
 
-                <ul className="mt-3 space-y-1 text-neutral-300 text-sm leading-relaxed">
+                <ul className="mt-3 space-y-1 text-muted-500 text-sm leading-relaxed">
                   {exp.bullets.map((b) => (
                     <li key={b} className="flex gap-2">
-                      <span className="mt-[6px] h-[6px] w-[6px] rounded-full bg-neutral-600 shrink-0 group-hover:bg-sky-500 transition-colors" />
+                      <span className="mt-[6px] h-[6px] w-[6px] rounded-full bg-neutral-600 shrink-0 group-hover:bg-primary-400 transition-colors" />
                       <span>{b}</span>
                     </li>
                   ))}
                 </ul>
 
-                <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-sky-400 group-hover:text-sky-300">
+                <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary-400 group-hover:text-primary-500">
                   View details <span aria-hidden>→</span>
                 </div>
               </div>
@@ -130,7 +139,7 @@ const lines = [
         <div className="mt-8 text-center">
           <Link
             href="/experiences"
-            className="text-sm text-sky-400 underline hover:text-sky-300"
+            className="text-sm text-primary-400 underline hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
           >
             View all experience →
           </Link>
@@ -138,13 +147,13 @@ const lines = [
       </section>
 
       {/* SKILLS */}
-      <section id="skills" className="py-24 border-t border-neutral-800 text-center">
+      <section id="skills" className="py-24 border-t border-white/10 text-center">
         <h2 className="text-3xl font-bold mb-6">Skills</h2>
         <ul className="flex flex-wrap justify-center gap-3 max-w-3xl mx-auto">
           {["Java", "TypeScript", "Flutter/Dart", "SQL", "Security Basics"].map((s) => (
             <li
               key={s}
-              className="text-sm border border-neutral-700 rounded-full px-4 py-2 bg-neutral-900"
+              className="text-sm border border-white/10 rounded-full px-4 py-2 bg-white/[0.05]"
             >
               {s}
             </li>
@@ -153,17 +162,21 @@ const lines = [
       </section>
 
       {/* RESUME */}
-      <section id="resume" className="py-24 border-t border-neutral-800 text-center">
+      <section id="resume" className="py-24 border-t border-white/10 text-center">
         <h2 className="text-3xl font-bold mb-6">Resume</h2>
-        <a className="underline text-sky-400 hover:text-sky-300" href="/resume.pdf" download>
+        <a
+          className="underline text-primary-400 hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
+          href="/resume.pdf"
+          download
+        >
           Download PDF
         </a>
       </section>
 
       {/* CONTACT */}
-      <section id="contact" className="py-24 border-t border-neutral-800 text-center">
+      <section id="contact" className="py-24 border-t border-white/10 text-center">
         <h2 className="text-3xl font-bold mb-6">Contact Me</h2>
-        <p className="text-neutral-300 mb-4">
+        <p className="text-muted-500 mb-4">
           Email:{" "}
           <a href="mailto:doubledan148@gmail.com" className="underline">
             doubledan148@gmail.com
@@ -173,14 +186,14 @@ const lines = [
           <a
             href="https://www.linkedin.com/in/danielpilant?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=android_app"
             target="_blank"
-            className="text-sky-400 hover:text-sky-300"
+            className="text-primary-400 hover:text-primary-500"
           >
             LinkedIn
           </a>
           <a
             href="https://github.com/DanielPilant"
             target="_blank"
-            className="text-sky-400 hover:text-sky-300"
+            className="text-primary-400 hover:text-primary-500"
           >
             GitHub
           </a>

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,3 +1,5 @@
+// CHANGELOG:
+// - Updated project detail page styling to new palette.
 import { projects } from "@/data/projects";
 import Link from "next/link";
 
@@ -11,14 +13,14 @@ export default function ProjectPage({ params }: { params: { slug: string } }) {
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-16 min-h-[70vh] flex flex-col items-center justify-center">
-      <div className="w-full bg-neutral-900/80 rounded-2xl shadow-lg border border-neutral-800 p-8">
-        <Link href="/projects" className="text-sm underline text-neutral-400 hover:text-primary-400 transition">← Back to all projects</Link>
+      <div className="w-full border border-white/10 bg-white/[0.02] p-8 shadow-[0_0_0_1px_rgba(255,255,255,0.02)_inset]">
+        <Link href="/projects" className="text-sm underline text-primary-400 hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400">← Back to all projects</Link>
         <h1 className="text-4xl font-extrabold mt-4 mb-2 tracking-tight text-primary-400 drop-shadow-lg">{p.title}</h1>
-        <p className="mt-2 text-neutral-300 text-lg mb-4">{p.tagline}</p>
+        <p className="mt-2 text-muted-500 text-lg mb-4">{p.tagline}</p>
 
         <div className="flex flex-wrap gap-2 mt-2 mb-6">
           {p.tech.map((t) => (
-            <span key={t} className="text-xs rounded-full border border-neutral-700 px-2 py-1 bg-neutral-800/60 text-neutral-200">
+            <span key={t} className="text-xs rounded-full border border-white/10 px-2 py-1 bg-white/[0.05] text-foreground">
               {t}
             </span>
           ))}
@@ -26,10 +28,10 @@ export default function ProjectPage({ params }: { params: { slug: string } }) {
 
         <div className="flex gap-4 mt-6">
           {p.demo && (
-            <a href={p.demo} target="_blank" className="rounded-lg px-5 py-2 bg-primary-500 text-white font-semibold shadow hover:bg-primary-400 transition">Demo</a>
+            <a href={p.demo} target="_blank" className="inline-flex items-center justify-center px-5 py-2 text-sm font-medium border border-white/10 bg-primary-500/10 hover:bg-primary-500/20 hover:shadow-lg active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition">Demo</a>
           )}
           {p.repo && (
-            <a href={p.repo} target="_blank" className="rounded-lg px-5 py-2 border border-neutral-700 text-neutral-200 font-semibold hover:bg-neutral-800 transition">Code</a>
+            <a href={p.repo} target="_blank" className="inline-flex items-center justify-center px-5 py-2 text-sm font-medium border border-white/10 bg-transparent hover:bg-white/5 hover:shadow-lg active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition">Code</a>
           )}
         </div>
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,9 +1,11 @@
+// CHANGELOG:
+// - Simplified layout to use global background.
 import { projects } from "@/data/projects";
 import ProjectCard from "@/components/ProjectCard";
 
 export default function ProjectsPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16 min-h-[80vh] bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-950">
+    <main className="mx-auto max-w-6xl px-4 py-16 min-h-[80vh]">
       <h1 className="text-4xl font-extrabold text-center mb-10 tracking-tight text-primary-400 drop-shadow-lg">All Projects</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-3 gap-8">
         {projects.map((p) => (

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,12 +1,18 @@
+// CHANGELOG:
+// - Updated resume page styling to new palette with sharp corners.
 export default function ResumePage() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-16 flex flex-col items-center min-h-[70vh]">
-      <div className="w-full bg-neutral-900/80 rounded-2xl shadow-lg border border-neutral-800 p-8 flex flex-col items-center">
+      <div className="w-full border border-white/10 bg-white/[0.02] p-8 flex flex-col items-center shadow-[0_0_0_1px_rgba(255,255,255,0.02)_inset]">
         <h1 className="text-4xl font-extrabold mb-6 tracking-tight text-primary-400 drop-shadow-lg text-center">Resume</h1>
-        <a className="rounded-lg px-6 py-2 bg-primary-500 text-white font-semibold shadow hover:bg-primary-400 transition mb-6" href="/resume.pdf" download>
+        <a
+          className="inline-flex items-center justify-center px-6 py-2 text-sm font-medium border border-white/10 bg-primary-500/10 hover:bg-primary-500/20 hover:shadow-lg active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition mb-6"
+          href="/resume.pdf"
+          download
+        >
           Download PDF
         </a>
-        <iframe src="/resume.pdf" className="w-full h-[80vh] rounded-lg border border-neutral-800 bg-white" />
+        <iframe src="/resume.pdf" className="w-full h-[80vh] border border-white/10 bg-white" />
       </div>
     </main>
   );

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,4 +1,6 @@
 "use client";
+// CHANGELOG:
+// - Removed obsolete comment reference.
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -124,7 +126,7 @@ export default function BottomNav() {
   className={`group inline-flex items-center justify-center
               w-12 h-12 mx-1 rounded-full transition
               ${isActive
-                ? "bg-neutral-800 text-neutral-50"  // <-- was bg-sky-500...
+                ? "bg-neutral-800 text-neutral-50"
                 : "text-neutral-200 hover:bg-neutral-800/70"}`}
   aria-label={t.label}
 >

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,11 @@
+/**
+ * CHANGELOG:
+ * - Updated footer colors to new palette.
+ */
 export default function Footer() {
   return (
-    <footer className="border-t border-neutral-800 mt-16">
-      <div className="mx-auto max-w-6xl px-4 py-8 text-center text-sm text-neutral-500">
+    <footer className="border-t border-white/10 mt-16">
+      <div className="mx-auto max-w-6xl px-4 py-8 text-center text-sm text-muted-500">
         © {new Date().getFullYear()} Daniel Pilant · Built with Next.js & Tailwind CSS
       </div>
     </footer>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,35 +1,43 @@
+"use client";
+/**
+ * CHANGELOG:
+ * - Added blur backdrop, active link styling and focus-visible rings.
+ */
 import Link from "next/link";
 import ThemeToggle from "./ThemeToggle";
+import { usePathname } from "next/navigation";
 
 function Navbar() {
+  const pathname = usePathname();
+  const links = [
+    { href: "/projects", label: "Projects" },
+    { href: "/resume", label: "Resume" },
+    { href: "/contact", label: "Contact" },
+  ];
+
   return (
-    <header className="sticky top-0 z-50 border-b border-neutral-800 bg-neutral-900/70 backdrop-blur-md supports-[backdrop-filter]:bg-neutral-900/60">
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-black/30 elevate">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         <Link
           href="/"
-          className="font-semibold tracking-tight transition-colors hover:text-sky-400"
+          className="font-semibold tracking-tight opacity-90 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition"
         >
           Daniel Pilant • Software Engineer
         </Link>
         <nav className="hidden md:flex items-center gap-6 text-sm">
-          <Link
-            href="/projects"
-            className="opacity-80 transition-colors hover:opacity-100 hover:text-sky-400"
-          >
-            Projects
-          </Link>
-          <Link
-            href="/resume"
-            className="opacity-80 transition-colors hover:opacity-100 hover:text-sky-400"
-          >
-            Resume
-          </Link>
-          <Link
-            href="/contact"
-            className="opacity-80 transition-colors hover:opacity-100 hover:text-sky-400"
-          >
-            Contact
-          </Link>
+          {links.map((l) => {
+            const active = pathname === l.href;
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                aria-current={active ? "page" : undefined}
+                className={`opacity-80 hover:opacity-100 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 ${active ? "text-primary-400" : ""}`}
+              >
+                {l.label}
+              </Link>
+            );
+          })}
         </nav>
         <div className="ml-4">
           <ThemeToggle />

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,3 +1,7 @@
+/**
+ * CHANGELOG:
+ * - Sharpened corners, new color system and focus styles.
+ */
 import Link from "next/link";
 import Image from "next/image";
 import type { Project } from "@/data/projects";
@@ -6,11 +10,11 @@ export default function ProjectCard({ p }: { p: Project }) {
   return (
     <Link
       href={`/projects/${p.slug}`}
-      className="group relative block overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900/60 shadow-lg transition-all duration-300 hover:border-sky-500 hover:shadow-xl"
+      className="group relative block overflow-hidden border border-white/10 bg-white/[0.02] hover:bg-white/[0.04] transition shadow-[0_0_0_1px_rgba(255,255,255,0.02)_inset] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info-500"
     >
       {/* Featured badge */}
       {p.featured && (
-        <span className="absolute top-3 right-3 z-10 rounded-full bg-sky-500/90 px-3 py-1 text-xs font-semibold tracking-wide text-white shadow">
+        <span className="absolute top-3 right-3 z-10 rounded-full bg-primary-500/90 px-3 py-1 text-xs font-semibold tracking-wide text-white shadow">
           Featured
         </span>
       )}
@@ -27,25 +31,25 @@ export default function ProjectCard({ p }: { p: Project }) {
             priority={false}
           />
         ) : (
-          <div className="absolute inset-0 grid place-items-center text-neutral-500 bg-neutral-800">
+          <div className="absolute inset-0 grid place-items-center text-muted-500 bg-white/[0.05]">
             No image
           </div>
         )}
-        <div className="absolute inset-0 bg-gradient-to-t from-neutral-950/60 to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
       </div>
 
       {/* Text */}
       <div className="p-6">
-        <div className="mb-1 text-xl font-bold transition-colors duration-200 group-hover:text-sky-400">
+        <div className="mb-1 text-xl font-bold decoration-primary-400 underline-offset-4 group-hover:underline transition">
           {p.title}
         </div>
-        <div className="text-neutral-400 text-base mt-1 line-clamp-2 min-h-[2.5em]">{p.tagline}</div>
+        <div className="text-muted-500 text-base mt-1 line-clamp-2 min-h-[2.5em]">{p.tagline}</div>
 
         <div className="flex flex-wrap gap-2 mt-4">
           {p.tech.slice(0, 4).map((t) => (
             <span
               key={t}
-              className="text-xs rounded-full border border-neutral-700/80 px-2 py-1 bg-neutral-800/60 text-neutral-200"
+              className="text-xs rounded-full border border-white/10 px-2 py-1 bg-white/[0.05] text-foreground"
             >
               {t}
             </span>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,3 +1,7 @@
+/**
+ * CHANGELOG:
+ * - Adopted new color tokens and sharp corners with focus styles.
+ */
 "use client";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
@@ -10,7 +14,7 @@ export default function ThemeToggle() {
   if (!mounted) {
     return (
       <button
-        className="rounded-xl border border-neutral-700 px-3 py-2 text-sm opacity-70"
+        className="border border-white/10 px-3 py-2 text-sm opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition"
         aria-label="Toggle theme"
       >
         …
@@ -25,7 +29,7 @@ export default function ThemeToggle() {
     <div className="inline-flex items-center gap-2">
       <button
         onClick={() => setTheme(isDark ? "light" : "dark")}
-        className="rounded-xl border border-neutral-700 px-3 py-2 text-sm hover:bg-neutral-900 transition-colors"
+        className="border border-white/10 px-3 py-2 text-sm hover:bg-white/5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
         aria-label="Toggle theme"
       >
         {isDark ? (
@@ -46,13 +50,13 @@ export default function ThemeToggle() {
         )}
       </button>
 
-  {/* System mode toggle (optional) */}
+      {/* System mode toggle (optional) */}
       <button
         onClick={() => setTheme("system")}
-        className={`rounded-xl border px-3 py-2 text-xs transition-colors
+        className={`border px-3 py-2 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400
           ${theme === "system"
-            ? "border-sky-600 text-sky-400"
-            : "border-neutral-700 text-neutral-400 hover:bg-neutral-900"}`}
+            ? "border-primary-600 text-primary-400"
+            : "border-white/10 text-muted-500 hover:bg-white/5"}`}
       >
         System
       </button>

--- a/components/Typewriter.tsx
+++ b/components/Typewriter.tsx
@@ -1,4 +1,6 @@
 "use client";
+// CHANGELOG:
+// - Updated typewriter styles to new palette with sharp corners.
 import { useEffect, useMemo, useRef, useState } from "react";
 
 type Props = {
@@ -65,10 +67,10 @@ export default function Typewriter({
 
   return (
     <div
-      className={`inline-flex items-center rounded-xl border border-neutral-800/60 bg-neutral-900/40 px-3 py-2 shadow-md ${className}`}
+      className={`inline-flex items-center border border-white/10 bg-white/[0.02] px-3 py-2 shadow-md ${className}`}
       aria-live="polite"
     >
-      <code className="font-mono text-base md:text-lg leading-6 text-neutral-200">
+      <code className="font-mono text-base md:text-lg leading-6 text-foreground">
         {text}
       </code>
   {/* The caret ("|") with blink animation. Note the arbitrary value for animation */}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,8 @@
+/**
+ * CHANGELOG:
+ * - Extended vibrant color palette and sharp corner defaults.
+ * - Set default transition duration.
+ */
 import type { Config } from "tailwindcss";
 
 const config: Config = {
@@ -5,9 +10,32 @@ const config: Config = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
-  "./pages/**/*.{js,ts,jsx,tsx,mdx}", // If there are no pages – doesn't hurt
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}", // If there are no pages – doesn't hurt
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        background: "#0b1220",
+        foreground: "#e6ebf5",
+        primary: { 400: "#22d3ee", 500: "#06b6d4", 600: "#0891b2" },
+        accent: { 400: "#f472b6", 500: "#ec4899", 600: "#db2777" },
+        info: { 500: "#60a5fa" },
+        success: { 500: "#34d399" },
+        warning: { 500: "#f59e0b" },
+        muted: { 500: "#64748b" },
+      },
+      borderRadius: {
+        DEFAULT: "0",
+        lg: "0",
+        md: "0",
+        sm: "0",
+      },
+      transitionDuration: {
+        DEFAULT: "200ms",
+      },
+    },
+  },
   plugins: [],
 };
+
 export default config;


### PR DESCRIPTION
## Summary
- extend Tailwind palette with sharp corners and base transitions
- introduce animated gradient background with reduced-motion support
- polish navigation, hero, buttons and project cards for colorful, accessible UX

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd36af92c8832a8f4aa6556dd97934